### PR TITLE
Solution#1500

### DIFF
--- a/packages/vehicle-lifecycle-model/models/vda.cto
+++ b/packages/vehicle-lifecycle-model/models/vda.cto
@@ -134,7 +134,7 @@ transaction ScrapVehicle extends VehicleTransaction {
 transaction UpdateSuspicious extends VehicleTransaction {
   o String message
 }
-transaction ScrapAllVehiclesByColourTxn  {
+transaction ScrapAllVehiclesByColourTxn {
   o String colour
 }
 event ScrapVehicleEvent {

--- a/packages/vehicle-lifecycle-model/models/vda.cto
+++ b/packages/vehicle-lifecycle-model/models/vda.cto
@@ -134,7 +134,7 @@ transaction ScrapVehicle extends VehicleTransaction {
 transaction UpdateSuspicious extends VehicleTransaction {
   o String message
 }
-transaction ScrapAllVehiclesByColour  {
+transaction ScrapAllVehiclesByColourTxn  {
   o String colour
 }
 event ScrapVehicleEvent {


### PR DESCRIPTION
Problem
The issue #1500 deals with the fact that a query in vehicle lifecycle network is not running.

Solution
The query Native is not supported now. The feature of Named Query has been implemented instead. The same is added here in. A suggestion is made after code review to rename a transaction ScrapAllVehiclesByColour to ScrapAllVehiclesByColourTxn to make code easily readable. For that purpose a change is made in model file (*.cto file) and added.

TestCase
None