### PR TITLE
after review of solution of 1500

### DIFF
--- a/packages/vehicle-lifecycle-model/models/vda.cto
+++ b/packages/vehicle-lifecycle-model/models/vda.cto
@@ -134,7 +134,7 @@ transaction ScrapVehicle extends VehicleTransaction {
 transaction UpdateSuspicious extends VehicleTransaction {
   o String message
 }
-transaction ScrapAllVehiclesByColour  {
+transaction ScrapAllVehiclesByColourTxn  {
   o String colour
 }
 event ScrapVehicleEvent {


### PR DESCRIPTION
Problem
The issue #1500 deals with the fact that a query in vehicle lifecycle network is not running.

Solution
The query Native is not supported now. The feature of Named Query has been implemented instead. After code review, a change is suggested to rename a transaction ScrapAllVehiclesByColour to ScarpAllVehiclesByColourTxn. For this a change is made in model file vda.cto of vehicle network.

TestCase
None